### PR TITLE
fix header guards. measure up and down independently

### DIFF
--- a/src/skadi/util.cc
+++ b/src/skadi/util.cc
@@ -17,19 +17,23 @@ namespace valhalla {
       if(heights.size() < 2)
         return deltas;
 
-      double total_distance = 0;
+      //measure amount of downward and upward change over the distance independently
+      double down = 0, up = 0;
       for(auto h = heights.cbegin() + 1; h != heights.cend(); ++h) {
         auto diff = static_cast<float>(*h - *std::prev(h));
-        if(diff > 0)
+        if(diff > 0) {
           deltas.second += diff;
-        else
+          up += interval_distance;
+        }
+        else {
           deltas.first -= diff;
-        total_distance += interval_distance;
+          down += interval_distance;
+        }
       }
 
       //clamp from 0 to max and get ratio of max
-      deltas.first = clamp(deltas.first / total_distance, 0.0, maximum_grade) / maximum_grade;
-      deltas.second = clamp(deltas.second / total_distance, 0.0, maximum_grade) / maximum_grade;
+      deltas.first = clamp(deltas.first / down, 0.0, maximum_grade) / maximum_grade;
+      deltas.second = clamp(deltas.second / up, 0.0, maximum_grade) / maximum_grade;
       return deltas;
     }
   }

--- a/test/util.cc
+++ b/test/util.cc
@@ -6,12 +6,12 @@ namespace {
 
   void deltas() {
 
-    auto d = skadi::discretized_deltas({0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0}, 1.0, 6);
-    if(d.first != (50.0/10.0)/6.0)
+    auto d = skadi::discretized_deltas({0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0}, 1.0, 6);
+    if(d.first != (5.0/5.0)/6.0)
       throw std::runtime_error("Descent wasn't right");
-    if(d.second != (50.0/10.0)/6.0)
+    if(d.second != (5.0/5.0)/6.0)
       throw std::runtime_error("Ascent wasn't right");
-    d = skadi::discretized_deltas({0, 10, 0, 10, 0, 10, 0, 10, 0, 10, 0}, 1.0, 4.9);
+    d = skadi::discretized_deltas({0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0}, 1.0, 0.9);
     if(d.first != 1.0)
       throw std::runtime_error("Descent should have been clipped");
     if(d.second != 1.0)

--- a/valhalla/skadi/util.h
+++ b/valhalla/skadi/util.h
@@ -1,5 +1,5 @@
-#ifndef __VALHALLA_SAMPLE_H__
-#define __VALHALLA_SAMPLE_H__
+#ifndef __VALHALLA_UTIL_H__
+#define __VALHALLA_UTIL_H__
 
 #include <utility>
 #include <vector>
@@ -23,4 +23,4 @@ namespace valhalla {
 }
 
 
-#endif //__VALHALLA_SAMPLE_H__
+#endif //__VALHALLA_UTIL_H__


### PR DESCRIPTION
header guards were broken and therefore we couldnt use this header in other projects.

this measures ascent and descent independently in terms of distance so as to get a better idea of grade. basically it computes avg uphill grade and avg downhill grade separately for the uphill sections vs the downhill sections.