### PR TITLE
Estimate Grade

### DIFF
--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -2,6 +2,7 @@
 set -e
 
 export LD_LIBRARY_PATH=.:`cat /etc/ld.so.conf.d/* | grep -v -E "#" | tr "\\n" ":" | sed -e "s/:$//g"`
+sudo apt-get update
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/ubuntu-toolchain-r-test-$(lsb_release -c -s).list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
 sudo apt-get install -y autoconf automake libtool make gcc-4.9 g++-4.9 libboost1.54-dev libboost-program-options1.54-dev libboost-filesystem1.54-dev libboost-system1.54-dev libboost-thread1.54-dev lcov libcurl4-openssl-dev geotiff-bin libgeotiff-dev libgeotiff2

--- a/src/skadi/util.cc
+++ b/src/skadi/util.cc
@@ -3,7 +3,7 @@
 namespace {
 
   template <class T>
-  T clamp(T val, T low, T high) {
+  T clamp(T val, const T low, const T high) {
     return std::min<T>(std::max<T>(val, low), high);
   }
 
@@ -11,30 +11,33 @@ namespace {
 
 namespace valhalla {
   namespace skadi {
-    std::pair<double, double> discretized_deltas(const std::vector<double>& heights, const double interval_distance, const double maximum_grade){
-      //nothing to do here
-      std::pair<double, double> deltas{0, 0};
-      if(heights.size() < 2)
-        return deltas;
 
-      //measure amount of downward and upward change over the distance independently
-      double down = 0, up = 0;
-      for(auto h = heights.cbegin() + 1; h != heights.cend(); ++h) {
-        auto diff = static_cast<float>(*h - *std::prev(h));
-        if(diff > 0) {
-          deltas.second += diff;
-          up += interval_distance;
-        }
-        else {
-          deltas.first -= diff;
-          down += interval_distance;
-        }
-      }
-
-      //clamp from 0 to max and get ratio of max
-      deltas.first = clamp(deltas.first / down, 0.0, maximum_grade) / maximum_grade;
-      deltas.second = clamp(deltas.second / up, 0.0, maximum_grade) / maximum_grade;
-      return deltas;
+    double energy_weighting(double& grade) {
+      //dont consider anything steeper than -10% or +15%
+      grade = clamp(grade, -10.0, 15.0);
+      //ascent gets weighted more than descent
+      return 1.0 + grade / (grade > 0 ? 7.0 : 17.0);
     }
+
+    double weighted_grade(const std::vector<double>& heights, const double interval_distance, const std::function<double (double&)>& grade_weighting){
+      //grab the scaled grade for each section
+      double total_grade = 0;
+      double total_weight = 0;
+      //multiply grades by 100 to move from 0-1 into 0-100 for grade percentage
+      auto scale = 100.0 / interval_distance;
+      for(auto h = heights.cbegin() + 1; h != heights.cend(); ++h) {
+        //get the grade for this section
+        auto grade = (*h - *std::prev(h)) * scale;
+        //find the weight and possibly change the grade
+        auto weight = grade_weighting(grade);
+        //keep this part of weighted grade
+        total_grade += grade * weight;
+        //keep this part of weight
+        total_weight += weight;
+      }
+      //get the average weighted grade by homogenizing total weight
+      return total_grade * (1.0 / total_weight);
+    }
+
   }
 }

--- a/test/util.cc
+++ b/test/util.cc
@@ -1,29 +1,37 @@
 #include "test.h"
 #include "skadi/util.h"
+
+#include <valhalla/midgard/util.h>
 using namespace valhalla;
 
 namespace {
 
-  void deltas() {
+  void grade() {
+    //we'll do a series of hundred percent grades up and down
+    auto down_grade = -100.0;
+    auto down_weight = skadi::energy_weighting(down_grade);
+    auto up_grade = 100.0;
+    auto up_weight = skadi::energy_weighting(up_grade);
+    auto answer = (down_grade * down_weight + up_grade * up_weight) / (down_weight + up_weight);
 
-    auto d = skadi::discretized_deltas({0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0}, 1.0, 6);
-    if(d.first != (5.0/5.0)/6.0)
-      throw std::runtime_error("Descent wasn't right");
-    if(d.second != (5.0/5.0)/6.0)
-      throw std::runtime_error("Ascent wasn't right");
-    d = skadi::discretized_deltas({0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0}, 1.0, 0.9);
-    if(d.first != 1.0)
-      throw std::runtime_error("Descent should have been clipped");
-    if(d.second != 1.0)
-      throw std::runtime_error("Ascent should have been clipped");
+    //check it
+    auto grade = skadi::weighted_grade({0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0}, 1.0);
+    if(!midgard::equal(grade, answer))
+      throw std::runtime_error("Weighted grade was not right");
+
+    //check another
+    answer = (down_grade * down_weight * 3 + up_grade * up_weight) / (down_weight * 3 + up_weight);
+    grade = skadi::weighted_grade({0, 1, 0, -1, -2}, 1.0);
+    if(!midgard::equal(grade, answer))
+      throw std::runtime_error("Weighted grade was not right");
   }
 
 }
 
 int main() {
-  test::suite suite("sample");
+  test::suite suite("util");
 
-  suite.test(TEST_CASE(deltas));
+  suite.test(TEST_CASE(grade));
 
   return suite.tear_down();
 }

--- a/valhalla/skadi/util.h
+++ b/valhalla/skadi/util.h
@@ -1,23 +1,32 @@
 #ifndef __VALHALLA_UTIL_H__
 #define __VALHALLA_UTIL_H__
 
-#include <utility>
 #include <vector>
+#include <functional>
 
 namespace valhalla {
   namespace skadi {
 
-    /*
-     * Returns the positive descent and positive ascent as a ratio of the max grade
-     *
-     * @param    heights  the height reading at each sampled location
-     * @param    interval_distance  the distance between each sampled location
-     * @param    maximum_grade  the maximum grade. if a computed grade is larger than
-     *           this value its ratio will be returned as 1
-     * @return   .first  = the descent over distance clamped to max grade and given as a ratio of same
-     *           .second = the ascent over distance clamped to max grade and given as a ratio of same
+    /* Clamps the grade to between -10 and +15. Grades greater than 0 are weighted
+     * using 1 + g / 7. This gives (grade,weight) of (0,1), (6,1.9), (15,3.2).
+     * Grades less than 0 are weighted using 1 + g / 17, which gives (grade,weight)
+     * of (0,1), (-6,.6), (-10,.4).
      */
-    std::pair<double, double> discretized_deltas(const std::vector<double>& heights, const double interval_distance, const double maximum_grade);
+    double energy_weighting(double& grade);
+
+    /*
+     * Returns the normalized grade using the weighting method provided. Each sections
+     * grade is computed. The provided weighting function is applied to each grade. The
+     * weightings are then normalized. The result is approximate most important grade
+     * for the given stretch of heights.
+     *
+     * @param    heights            the height reading at each sampled location
+     * @param    interval_distance  the distance between each sampled location
+     * @param    grade_weighting    the function which provides the weight that should be applied to a specific grade
+     *                              the grade is pass by reference so you may clamp it to a range if you like
+     * @return   the approximate grade on a scale from -100 to +100
+     */
+    double weighted_grade(const std::vector<double>& heights, const double interval_distance, const std::function<double (double&)>& grade_weighting = energy_weighting);
 
   }
 }


### PR DESCRIPTION
This pr adds a method to Skadi which allows one to estimate the grade of a set of heights. The grade is computed using a linear combination whose coefficients are computed  using a weighting function. One such function is supplied by default but the user may specify their own.

The default weighting function gives higher weights to steeper uphill/positive grades and less weights to steeper downhill grades. The intuition is that descending will either take less time or less energy and so is overall less important to a costing method.

It should be noted that the final value is indeed a grade on the between -100 and +100. If you use the default weighting function the range is clamped between -10 and +15. We'll map this to the 4bit value stored on the directed edge so we can use the estimated grade to influence costing.

