### PR TITLE
add service limit for skadi in the number of shape points

### DIFF
--- a/src/skadi/service.cc
+++ b/src/skadi/service.cc
@@ -199,6 +199,7 @@ namespace {
       }
 
       //resample the shape
+      bool resampled = false;
       if(resample_distance) {
         if(*resample_distance < 10)
           throw std::runtime_error("'resample_distance' must be >= 10.0 meters");
@@ -210,12 +211,13 @@ namespace {
           //reencode it for display if they sent it encoded
           if(encoded_polyline)
             *encoded_polyline = midgard::encode(shape);
+          resampled = true;
         }
       }
 
       //there are limits though
       if(shape.size() > max_shape)
-        throw std::runtime_error("Too many shape points (" + std::to_string(shape.size()) + "). The limit is " + std::to_string(max_shape));
+        throw std::runtime_error("Too many shape points (" + std::to_string(shape.size()) + (resampled ? " after resampling" : "") + "). The limit is " + std::to_string(max_shape));
     }
 
 

--- a/src/skadi/service.cc
+++ b/src/skadi/service.cc
@@ -200,7 +200,9 @@ namespace {
 
       //resample the shape
       if(resample_distance) {
-        if(*resample_distance >= 10) {
+        if(*resample_distance < 10)
+          throw std::runtime_error("'resample_distance' must be >= 10.0 meters");
+        if(shape.size() > 1) {
           //resample the shape but make sure to keep the first and last shapepoint
           auto last = shape.back();
           shape = midgard::resample_spherical_polyline(shape, *resample_distance);
@@ -209,8 +211,6 @@ namespace {
           if(encoded_polyline)
             *encoded_polyline = midgard::encode(shape);
         }
-        else
-          throw std::runtime_error("'resample_distance' must be >= 10.0 meters");
       }
 
       //there are limits though

--- a/src/skadi/service.cc
+++ b/src/skadi/service.cc
@@ -216,8 +216,10 @@ namespace {
       }
 
       //there are limits though
-      if(shape.size() > max_shape)
-        throw std::runtime_error("Too many shape points (" + std::to_string(shape.size()) + (resampled ? " after resampling" : "") + "). The limit is " + std::to_string(max_shape));
+      if(shape.size() > max_shape) {
+        throw std::runtime_error("Too many shape points (" + std::to_string(shape.size()) +
+            (resampled ? " after resampling" : "") + "). The limit is " + std::to_string(max_shape));
+      }
     }
 
 

--- a/test/service.cc
+++ b/test/service.cc
@@ -52,6 +52,7 @@ namespace {
     config.add("skadi.service.proxy", "ipc://test_skadi_proxy");
     config.add("httpd.service.loopback", "ipc://test_skadi_results");
     config.add("additional_data.elevation", "test/data/");
+    config.add("service_limits.max_shape", "100");
 
     std::thread worker(valhalla::skadi::run_service, config);
     worker.detach();


### PR DESCRIPTION
sets the skadi input shape limitation to 750k points (which comes back from the service in about 2 seconds)

also refactors the errors a bit so that more appropriate errors come back for various cases