### PR TITLE
Use stat(), not stat64().

### DIFF
--- a/src/skadi/sample.cc
+++ b/src/skadi/sample.cc
@@ -67,8 +67,8 @@ namespace {
   }
 
   uint64_t file_size(const std::string& file_name) {
-    struct stat64 s;
-    int rc = stat64(file_name.c_str(), &s);
+    struct stat s;
+    int rc = stat(file_name.c_str(), &s);
     return rc == 0 ? s.st_size : -1;
   }
 


### PR DESCRIPTION
On modern systems stat() and struct stat are already 64 bits. Plus, stat64 is not standardized and many systems don’t implement it, including at least OpenBSD and FreeBSD.